### PR TITLE
fix filter with url admin && mod

### DIFF
--- a/src/main/java/vn/edu/hcmuaf/fit/sourcedoannoithat/controller/AuthorizationFilter.java
+++ b/src/main/java/vn/edu/hcmuaf/fit/sourcedoannoithat/controller/AuthorizationFilter.java
@@ -33,14 +33,14 @@ public class AuthorizationFilter implements Filter {
             res.sendRedirect(contextPath + "/blockedaccount.jsp");
             return;
         }
-        if (uri.endsWith("mod.jsp")) {
+        if (uri.contains("/mod") || uri.endsWith("mod.jsp")) {
             if (role == null || role < 1) {
                 res.sendRedirect(contextPath + "/index.jsp");
                 return;
             }
         }
 
-        if (uri.endsWith("admin.jsp")) {
+        if (uri.contains("/admin") || uri.endsWith("admin.jsp")) {
             if (role == null || role < 2) {
                 res.sendRedirect(contextPath + "/index.jsp");
                 return;

--- a/src/main/java/vn/edu/hcmuaf/fit/sourcedoannoithat/dao/db/DBConnect.java
+++ b/src/main/java/vn/edu/hcmuaf/fit/sourcedoannoithat/dao/db/DBConnect.java
@@ -8,7 +8,7 @@ public class DBConnect {
     public Connection getConnection() throws Exception {
         Class.forName("com.mysql.cj.jdbc.Driver");
 
-        String url = "jdbc:mysql://localhost:3306/donoithat";
+        String url = "jdbc:mysql://localhost:3307/donoithat";
         String user = "root";
         String password = "";
 


### PR DESCRIPTION
Tôi xin nhận lỗi vì đã thiếu sót khi chỉ filter file jsp mà quên /admin và /mod, khiến người dùng thường vẫn có thể truy cập trái phép. Sự sơ suất này ảnh hưởng đến bảo mật, và tôi đã nhanh chóng khắc phục.